### PR TITLE
Add urf:zonalDisasterPreventionFacilitiesAllocation

### DIFF
--- a/plateau_plugin/plateau/models/urf_zone.py
+++ b/plateau_plugin/plateau/models/urf_zone.py
@@ -1170,6 +1170,11 @@ URF_DISTRICT_PLAN = FeatureProcessingDefinition(
                     path="./urf:specifiedZonalDisasterPreventionFacilitiesAllocation",
                     datatype="string",
                 ),
+                Attribute(
+                    name="zonalDisasterPreventionFacilitiesAllocation",
+                    path="./urf:zonalDisasterPreventionFacilitiesAllocation",
+                    datatype="string",
+                ),
             ],
         ),
     ],


### PR DESCRIPTION
`DistrictPlan` の下位スキーマクラス `urf:DisasterPreventionBlockImprovementZonePlan` に定義されている属性 `urf:zonalDisasterPreventionFacilitiesAllocation` が抜けているようだったので追加します。