### PR TITLE
Add zonalDisasterPreventionFacilities to semantic_parts

### DIFF
--- a/plateau_plugin/plateau/models/urf_zone.py
+++ b/plateau_plugin/plateau/models/urf_zone.py
@@ -1188,6 +1188,7 @@ URF_DISTRICT_PLAN = FeatureProcessingDefinition(
         semantic_parts=[
             "./urf:districtDevelopmentPlan/urf:*",
             "./urf:promotionDistrict/urf:*",
+            "./urf:zonalDisasterPreventionFacilities/urf:ZonalDisasterPreventionFacility"
         ],
     ),
 )


### PR DESCRIPTION
`urf:DistrictPlan` の下位スキーマクラス `urf:DisasterPreventionBlockImprovementZonePlan` では「自身に定義された関連役割」として `zonalDisasterPreventionFacilities` が定義されているので、DistrictPlan の emissions に semantic_parts として追加します。