### PR TITLE
仕様上2次元の地物/LoDは2次元で読み込む

### DIFF
--- a/plateau_plugin/geometry.py
+++ b/plateau_plugin/geometry.py
@@ -18,10 +18,10 @@ from .plateau.types import (
 )
 
 
-def to_qgis_geometry(src_geom: Geometry, is3d: bool) -> QgsGeometry:
+def to_qgis_geometry(src_geom: Geometry, as2d: bool) -> QgsGeometry:
     """Convert geometries from PLATEAU module into QGIS geometry"""
 
-    if not is3d:
+    if as2d:
         return _to_qgis_geometry_2d(src_geom)
 
     if isinstance(src_geom, PolygonCollection):

--- a/plateau_plugin/plateau/models/base.py
+++ b/plateau_plugin/plateau/models/base.py
@@ -30,6 +30,9 @@ class GeometricAttribute:
     only_direct: Optional[list[str]] = None
     """このFeatureの直下にあるジオメトリを収集するための element path"""
 
+    is2d: bool = False
+    """仕様上の実態が2次元データかどうか"""
+
 
 @dataclass
 class GeometricAttributes:
@@ -126,11 +129,11 @@ class FeatureProcessingDefinition:
                     em
                     and any(elem.find(p, nsmap) is not None for p in em.lod_detection)
                 )
-                for em in self.emission_list
+                for em in self.lod_list
             )
 
     @cached_property
-    def emission_list(self) -> tuple[Optional[GeometricAttribute], ...]:
+    def lod_list(self) -> tuple[Optional[GeometricAttribute], ...]:
         return (
             self.geometries.lod0,
             self.geometries.lod1,

--- a/plateau_plugin/plateau/models/building.py
+++ b/plateau_plugin/plateau/models/building.py
@@ -439,6 +439,7 @@ BUILDING = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./bldg:lod0RoofEdge", "./bldg:lod0FootPrint"],
             collect_all=[
                 ".//bldg:lod0RoofEdge//gml:Polygon",

--- a/plateau_plugin/plateau/models/generics.py
+++ b/plateau_plugin/plateau/models/generics.py
@@ -37,6 +37,7 @@ GENERIC_CITY_OBJECT = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./gen:lod0Geometry"],
             collect_all=[
                 "./gen:lod0Geometry//gml:Polygon",

--- a/plateau_plugin/plateau/models/landuse.py
+++ b/plateau_plugin/plateau/models/landuse.py
@@ -151,10 +151,12 @@ LAND_USE = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(  # NOTE: PLATEAU 2.0 compatibility
+            is2d=True,
             lod_detection=["./luse:lod0MultiSurface"],
             collect_all=["./luse:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./luse:lod1MultiSurface"],
             collect_all=["./luse:lod1MultiSurface//gml:Polygon"],
         ),

--- a/plateau_plugin/plateau/models/transportation.py
+++ b/plateau_plugin/plateau/models/transportation.py
@@ -185,15 +185,18 @@ ROAD = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod0Network"],
             collect_all=["./tran:lod0Network//gml:LineString"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod1MultiSurface"],
             collect_all=["./tran:lod1MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod1MultiSurface//gml:Polygon"],
         ),
         lod2=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod2MultiSurface"],
             collect_all=[".//tran:lod2MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod2MultiSurface//gml:Polygon"],
@@ -276,15 +279,18 @@ RAILWAY = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod0Network"],
             collect_all=["./tran:lod0Network//gml:LineString"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod1MultiSurface"],
             collect_all=["./tran:lod1MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod1MultiSurface//gml:Polygon"],
         ),
         lod2=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod2MultiSurface"],
             collect_all=[".//tran:lod2MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod2MultiSurface//gml:Polygon"],
@@ -379,15 +385,18 @@ TRACK = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod0Network"],
             collect_all=["./tran:lod0Network//gml:LineString"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod1MultiSurface"],
             collect_all=["./tran:lod1MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod1MultiSurface//gml:Polygon"],
         ),
         lod2=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod2MultiSurface"],
             collect_all=[".//tran:lod2MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod2MultiSurface//gml:Polygon"],
@@ -590,15 +599,18 @@ SQUARE = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod0Network"],
             collect_all=["./tran:lod0Network//gml:LineString"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod1MultiSurface"],
             collect_all=["./tran:lod1MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod1MultiSurface//gml:Polygon"],
         ),
         lod2=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod2MultiSurface"],
             collect_all=[".//tran:lod2MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod2MultiSurface//gml:Polygon"],
@@ -700,15 +712,18 @@ WATERWAY = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod0Network"],
             collect_all=["./tran:lod0Network//gml:LineString"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod1MultiSurface"],
             collect_all=["./tran:lod1MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod1MultiSurface//gml:Polygon"],
         ),
         lod2=GeometricAttribute(
+            is2d=True,
             lod_detection=["./tran:lod2MultiSurface"],
             collect_all=[".//tran:lod2MultiSurface//gml:Polygon"],
             only_direct=["./tran:lod2MultiSurface//gml:Polygon"],
@@ -803,6 +818,7 @@ TRAFFIC_AREA = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod2=GeometricAttribute(
+            is2d=True,
             lod_detection=[
                 "./tran:lod2MultiSurface",
                 "./uro:railwayTrackAttribute/uro:RailwayTrackAttribute/uro:lod2Network",

--- a/plateau_plugin/plateau/models/urf_landslide.py
+++ b/plateau_plugin/plateau/models/urf_landslide.py
@@ -74,6 +74,7 @@ URF_SEDIMENT_DISASTER_PRONE_AREA = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=[
                 "./urf:lod1MultiSurface//gml:Polygon",

--- a/plateau_plugin/plateau/models/urf_zone.py
+++ b/plateau_plugin/plateau/models/urf_zone.py
@@ -185,10 +185,12 @@ URF_URBAN_PLANNING_AREA = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -265,10 +267,12 @@ URF_AREA_CLASSIFICATION = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -461,10 +465,12 @@ URF_DISTRICTS_AND_ZONES = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -517,10 +523,12 @@ URF_PROJECT_PROMOTION_AREA = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -951,10 +959,12 @@ URF_URBAN_FACILITY = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -1096,10 +1106,12 @@ URF_URBAN_DEVELOPMENT_PROJECT = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -1139,10 +1151,12 @@ URF_SCHEDULED_AREA_FOR_URBAN_DEVELOPMENT = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -1210,10 +1224,12 @@ URF_DISTRICT_PLAN = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -1282,10 +1298,12 @@ URF_DISTRICT_DEVELOPMENT_PLAN = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -1329,10 +1347,12 @@ URF_DISTRICT_FACILITY = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -1359,10 +1379,12 @@ URF_PROMOTION_DISTRICT = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),
@@ -1489,10 +1511,12 @@ URF_DISTRICT = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod0MultiSurface"],
             collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
         ),
         lod1=GeometricAttribute(
+            is2d=True,
             lod_detection=["./urf:lod1MultiSurface"],
             collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
         ),

--- a/plateau_plugin/plateau/models/uro_dm.py
+++ b/plateau_plugin/plateau/models/uro_dm.py
@@ -32,6 +32,7 @@ DM_GEOMETRIC = FeatureProcessingDefinition(
     ],
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./uro:lod0Geometry"],
             collect_all=[
                 "./uro:lod0Geometry//gml:Polygon",

--- a/plateau_plugin/plateau/models/uro_other_construction.py
+++ b/plateau_plugin/plateau/models/uro_other_construction.py
@@ -259,6 +259,7 @@ OTHER_CONSTRUCTION = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./uro:lod0Geometry"],
             collect_all=[
                 "./uro:lod0Geometry//gml:LineString",

--- a/plateau_plugin/plateau/models/uro_underground_building.py
+++ b/plateau_plugin/plateau/models/uro_underground_building.py
@@ -431,6 +431,7 @@ UNDERGROUND_BUILDING = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./bldg:lod0RoofEdge"],
             collect_all=[".//bldg:lod0RoofEdge//gml:Polygon"],
         ),

--- a/plateau_plugin/plateau/models/waterbody.py
+++ b/plateau_plugin/plateau/models/waterbody.py
@@ -255,6 +255,7 @@ WATER_BODY = FeatureProcessingDefinition(
     ),
     geometries=GeometricAttributes(
         lod0=GeometricAttribute(
+            is2d=True,
             lod_detection=["./wtr:lod0MultiCurve"],
             collect_all=["./wtr:lod0MultiCurve//gml:LineString"],
         ),

--- a/plateau_plugin/plateau/parser.py
+++ b/plateau_plugin/plateau/parser.py
@@ -258,7 +258,7 @@ class Parser:
             return
 
         # ジオメトリを読んで出力する
-        emission_for_lods = processor.emission_list
+        lod_defs = processor.lod_list
         has_lods = processor.detect_lods(elem, nsmap)
         for lod in (4, 3, 2, 1, 0):
             if not has_lods[lod]:
@@ -267,7 +267,7 @@ class Parser:
             if processor.geometries.lod_n is not None:
                 emission = processor.geometries.lod_n_paths
             else:
-                emission = emission_for_lods[lod]
+                emission = lod_defs[lod]
             if emission is None:
                 continue
 


### PR DESCRIPTION
仕様上、高さが0とされている地物/LoDは、2次元化オプションなしでも2次元化して読み込む（zを捨ててunaryUnionする）。

tran系のLOD2以下、LandUse、土砂災害-、都市計画決定情報、LoD0、DmGeometricなど

Close #25 