### PR TITLE
tsunamiのtypoを修正

### DIFF
--- a/plateau_plugin/plateau/models/attr_disaster_risk.py
+++ b/plateau_plugin/plateau/models/attr_disaster_risk.py
@@ -73,8 +73,8 @@ ATTR_DISASTER_RISK_RIVER_FLOODING = FeatureProcessingDefinition(
 )
 
 ATTR_DISASTER_RISK_TSUNAMI = FeatureProcessingDefinition(
-    id="uro:TsumaniRisk",
-    name="TsumaniRisk",
+    id="uro:TsunamiRisk",
+    name="TsunamiRisk",
     target_elements=[
         "uro:BuildingTsunamiRiskAttribute",
         "uro:TsunamiRiskAttribute",


### PR DESCRIPTION
出力されるTsunamiRiskテーブルにtypoがあったので修正しました

- 修正前
<img width="275" alt="image" src="https://github.com/MIERUNE/plateau-qgis-plugin-rev2/assets/98634289/1a68d1ed-2771-4daa-a44b-2e1e0ef90738">

- 修正後
<img width="275" alt="image" src="https://github.com/MIERUNE/plateau-qgis-plugin-rev2/assets/98634289/f7251293-04ad-4e8f-921d-5c4976f290e7">
