### PR TITLE
lodの値を地物の属性としても持たせる

### DIFF
--- a/plateau_plugin/algorithms/load_vector.py
+++ b/plateau_plugin/algorithms/load_vector.py
@@ -192,6 +192,7 @@ class PlateauVectorLoaderAlrogithm(QgsProcessingAlgorithm):
             # Set attributes
             feature.setAttribute("id", cityobj.id)
             feature.setAttribute("type", cityobj.type)
+            feature.setAttribute("lod", cityobj.lod)
             feature.setAttribute("name", cityobj.name)
             feature.setAttribute(
                 "creationDate",

--- a/plateau_plugin/algorithms/utils/layermanger.py
+++ b/plateau_plugin/algorithms/utils/layermanger.py
@@ -110,6 +110,7 @@ class LayerManager:
         attributes.extend(
             [
                 QgsField("type", QVariant.String),
+                QgsField("lod", QVariant.Int),
                 QgsField("name", QVariant.String),
                 QgsField("creationDate", QVariant.Date),
                 QgsField("terminationDate", QVariant.Date),


### PR DESCRIPTION
LODの値を、地物の属性として lod フィールドに持たせるようにする。

複数LODを1つのレイヤにまとめる場合に、各地物のLODを判別するために必要。

<img width="289" alt="Screenshot 2023-08-24 at 16 58 13" src="https://github.com/MIERUNE/plateau-qgis-plugin-rev2/assets/5351911/cd7965b8-4650-479d-9aa3-d48ae4debf56">
