### PR TITLE
plateau モジュールの外部パッケージ化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ endif
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
+update_dependencies:  ## Update PLATEAU library
+	git clone https://github.com/MIERUNE/plateau-py.git || true
+	rm -rf plateau_plugin/plateau
+	mv -f plateau-py/src/plateau plateau_plugin/
+	rm -rf plateau-py
+
 init:  ## Startup project
 ifeq ($(OS),Windows_NT)
 	$(QGIS_PYTHON) -m pip install poetry

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
-# plateau-qgis-plugin-rev2
+# plateau-qgis-plugin
 
-[PoC]
+A QGIS plugin for loading PLATEAU 3D city models. (PLATEAU 3D 都市モデルを読み込むための QGIS プラグイン)
+
+## 開発
 
 - QGIS 3.28 で動作させるため Python 3.9 の文法で実装する必要があります。
-- `plateau_plugin.plateau` モジュールは、将来切り出して QGIS 以外でも使うことを意図しています。QGIS に依存しない汎用的なパッケージとして実装してください。
+- PLATEAU データのパーサなどは [plateau-py](https://github.com/MIERUNE/plateau-py) パッケージとして分離されています。
 
-## 実行
-
-QGIS を使わずにテスト実行:
-
-```console
-cd plateau_plugin
-python3 -m plateau /path/to/city/udx/luse/563846_luse_6668_op.gml
-```
-
-QGIS にデプロイ (macOS):
+QGIS にデプロイする:
 
 ```console
 make deploy
+```
+
+最新の `plateau-py` を取り込む:
+
+```console
+make update_dependencies
 ```

--- a/plateau_plugin/algorithms/load_vector.py
+++ b/plateau_plugin/algorithms/load_vector.py
@@ -36,7 +36,7 @@ from qgis.core import (
 )
 
 from ..geometry import to_qgis_geometry
-from ..plateau.parser import ParserSettings, PlateauCityGmlParser
+from ..plateau.parse import ParserSettings, PlateauCityGmlParser
 from .utils.layermanger import LayerManager
 
 

--- a/plateau_plugin/plateau/__main__.py
+++ b/plateau_plugin/plateau/__main__.py
@@ -1,5 +1,5 @@
 """
-テスト実行用 __main__.py
+とりあえずのテスト実行用の __main__.py
 
 python3 -m plateau /path/to/21201_gifu-shi_2022_citygml_1_op/udx/fld/natl/kisogawa_ibigawa/53360501_fld_6697_l2_op.gml
 """
@@ -7,7 +7,7 @@ python3 -m plateau /path/to/21201_gifu-shi_2022_citygml_1_op/udx/fld/natl/kisoga
 import sys
 
 from .models import processors
-from .parser import ParserSettings, PlateauCityGmlParser
+from .parse.parser import ParserSettings, PlateauCityGmlParser
 
 if __name__ == "__main__":
     processors.validate_processors()

--- a/plateau_plugin/plateau/codelists/__init__.py
+++ b/plateau_plugin/plateau/codelists/__init__.py
@@ -15,7 +15,7 @@ from ..namespaces import BASE_NS as _NS
 class CodelistStore:
     """事前定義されたコードリストまたは頒布データの ./codelists./ ディレクトリからコードを検索する"""
 
-    def __init__(self, base_path: Path):
+    def __init__(self, base_path: Path) -> None:
         self._base_path = base_path
         self._cached: dict[str, Optional[dict[str, str]]] = {}
         self._predefined: dict[str, dict[str, str]] = {}

--- a/plateau_plugin/plateau/models/base.py
+++ b/plateau_plugin/plateau/models/base.py
@@ -157,7 +157,7 @@ class ProcessorRegistory:
 
     def __init__(
         self, processors: Optional[Iterable[FeatureProcessingDefinition]] = None
-    ):
+    ) -> None:
         self._tag_map: dict[str, FeatureProcessingDefinition] = {}
         self._id_map: dict[str, FeatureProcessingDefinition] = {}
         if processors:
@@ -180,7 +180,7 @@ class ProcessorRegistory:
             else:
                 yield name
 
-    def register_processor(self, processor: FeatureProcessingDefinition):
+    def register_processor(self, processor: FeatureProcessingDefinition) -> None:
         """Processor を登録する"""
         assert (
             processor.id not in self._id_map
@@ -202,7 +202,7 @@ class ProcessorRegistory:
         """XMLの要素名をもとに Processor を取得する"""
         return self._tag_map.get(target_tag)
 
-    def validate_processors(self):  # noqa: C901
+    def validate_processors(self) -> None:  # noqa: C901
         """Processor の定義を検証する処理 (テスト用)"""
         from pathlib import Path
 

--- a/plateau_plugin/plateau/namespaces.py
+++ b/plateau_plugin/plateau/namespaces.py
@@ -1,6 +1,7 @@
 """定数値"""
 
 import re
+from typing import Type
 
 BASE_NS = {
     # GML
@@ -38,12 +39,14 @@ class Namespace:
     特に、uro, urf のバージョン (2 or 3) が配布物ごとに異なることに対応する役目をする。
     """
 
-    def __init__(self, update: dict):
+    def __init__(self, update: dict) -> None:
         self.nsmap: dict[str, str] = dict(**BASE_NS, **update)
         self.inverted = {v: k for k, v in self.nsmap.items()}
 
     @classmethod
-    def from_document_nsmap(cls, src_nsmap: dict[str, str]) -> "Namespace":
+    def from_document_nsmap(
+        cls: Type["Namespace"], src_nsmap: dict[str, str]
+    ) -> "Namespace":
         """XML文書をもとに、接頭辞と名前空間の対応を作成する
 
         特に、与えられた文書において uro および urf 接頭辞が指すべきXML名前空間を特定する

--- a/plateau_plugin/plateau/parse/__init__.py
+++ b/plateau_plugin/plateau/parse/__init__.py
@@ -1,0 +1,3 @@
+from .parser import CityObjectParser, ParserSettings, PlateauCityGmlParser
+
+__all__ = ["ParserSettings", "PlateauCityGmlParser", "CityObjectParser"]

--- a/plateau_plugin/plateau/parse/appearance.py
+++ b/plateau_plugin/plateau/parse/appearance.py
@@ -1,30 +1,10 @@
-from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Iterable
 
 import lxml.etree as et
 import numpy as np
 
-from .namespaces import BASE_NS as _NS
-
-
-@dataclass
-class Material:
-    __slots__ = ("diffuse_color", "specular_color", "shininess")
-    diffuse_color: Optional[tuple[float, ...]]
-    specular_color: Optional[tuple[float, ...]]
-    shininess: Optional[float]
-
-
-@dataclass
-class Texture:
-    __slots__ = ("image_uri",)
-    image_uri: str
-
-
-@dataclass
-class Appearance:
-    target_material: dict[str, Material]
-    ring_texture: dict[str, tuple[Texture, np.ndarray]]
+from ..namespaces import BASE_NS as _NS
+from ..types import Appearance, Material, Texture
 
 
 def parse_appearances(doc: et._Element) -> Iterable[Appearance]:

--- a/plateau_plugin/plateau/parse/geometry.py
+++ b/plateau_plugin/plateau/parse/geometry.py
@@ -3,8 +3,8 @@ from typing import Iterable, Optional
 import lxml.etree as et
 import numpy as np
 
+from ..types import Geometry, LineStringCollection, PointCollection, PolygonCollection
 from .appearance import Appearance, Material, Texture
-from .types import Geometry, LineStringCollection, PointCollection, PolygonCollection
 
 
 def parse_geometry(  # noqa: C901 (TODO)

--- a/plateau_plugin/plateau/parse/parser.py
+++ b/plateau_plugin/plateau/parse/parser.py
@@ -5,13 +5,13 @@ from typing import Any, Iterable, Optional, Union
 
 import lxml.etree as et
 
-from .appearance import Appearance, parse_appearances
-from .codelists import CodelistStore
+from ..codelists import CodelistStore
+from ..models import processors
+from ..models.base import FeatureProcessingDefinition
+from ..namespaces import Namespace
+from ..types import Appearance, CityObject
+from .appearance import parse_appearances
 from .geometry import parse_geometry
-from .models import processors
-from .models.base import FeatureProcessingDefinition
-from .namespaces import Namespace
-from .types import CityObject
 
 _BOOLEAN_TRUE_STRINGS = frozenset({"true", "True", "1"})
 
@@ -42,7 +42,9 @@ class CityObjectParser:
         self._codelist_store = codelist_store
         self.appearance = appearance
 
-    def _get_id_and_name(self, elem: et._Element):
+    def _get_id_and_name(
+        self, elem: et._Element
+    ) -> tuple[Optional[str], Optional[str]]:
         """@gml:id と gml:name (あれば) を読む"""
         nsmap = self._nsmap
         gml_id = elem.get("{http://www.opengis.net/gml}id", None)
@@ -307,7 +309,7 @@ class CityObjectParser:
 class PlateauCityGmlParser:
     """PLATEAU の CityGML ファイルのパーサー"""
 
-    def __init__(self, filename: str, settings: ParserSettings):
+    def __init__(self, filename: str, settings: ParserSettings) -> None:
         self._base_dir = Path(filename).parent
         self._doc = et.parse(filename, None)
         self._settings = settings
@@ -321,7 +323,7 @@ class PlateauCityGmlParser:
             self._settings, ns=self._ns, codelist_store=codelists
         )
 
-    def load_apperance(self, theme: Optional[str] = None):
+    def load_apperance(self, theme: Optional[str] = None) -> None:
         for app in parse_appearances(self._doc):
             self._parser.appearance = app
             break

--- a/plateau_plugin/plateau/types.py
+++ b/plateau_plugin/plateau/types.py
@@ -4,7 +4,6 @@ from typing import Any, Literal, Optional, Union
 
 import numpy as np
 
-from .appearance import Material, Texture
 from .models.base import AttributeDatatype, FeatureProcessingDefinition
 
 
@@ -26,8 +25,8 @@ class PolygonCollection:
     polygons: list[list[np.ndarray]]
 
     # appearance
-    materials: Optional[list[Optional[Material]]]
-    textures: Optional[list[Optional[Texture]]]
+    materials: Optional[list[Optional["Material"]]]
+    textures: Optional[list[Optional["Texture"]]]
     uvs: Optional[list[Optional[list[np.ndarray]]]]
 
 
@@ -44,7 +43,7 @@ class CityObject:
     type: str
     """このFeatureの型名 (e.g. tran:Road, tran:TrafficArea, etc.)"""
 
-    id: str
+    id: Optional[str]
     """@gml:id"""
 
     name: Optional[str]
@@ -83,7 +82,7 @@ class TableDefinition:
     fields: list[FieldDefinition]
 
 
-def get_table_definition(cityobj: CityObject):
+def get_table_definition(cityobj: CityObject) -> TableDefinition:
     processor = cityobj.processor
     fields = [
         FieldDefinition("id", "string"),
@@ -107,3 +106,23 @@ def get_table_definition(cityobj: CityObject):
                 ), f"{prop.name}, {closed[prop.name]} != {prop.datatype}"
 
     return TableDefinition(fields=fields)
+
+
+@dataclass
+class Material:
+    __slots__ = ("diffuse_color", "specular_color", "shininess")
+    diffuse_color: Optional[tuple[float, ...]]
+    specular_color: Optional[tuple[float, ...]]
+    shininess: Optional[float]
+
+
+@dataclass
+class Texture:
+    __slots__ = ("image_uri",)
+    image_uri: str
+
+
+@dataclass
+class Appearance:
+    target_material: dict[str, Material]
+    ring_texture: dict[str, tuple[Texture, np.ndarray]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ select = [
 ignore = ["N802", "E501"]
 target-version = "py38"
 
+[tool.ruff.isort]
+known-third-party = ["plateau"]
+
 [tool.coverage.run]
 source = ['plateau_plugin']
 concurrency = ["thread"]


### PR DESCRIPTION
`plateau` モジュールを [plateau-py](https://github.com/MIERUNE/plateau-py) として分離する。

サブモジュールとしては扱うのは困難なため、 当該モジュールを `plateau_plugin` パッケージ内にコピーして取り込む方法を採用する。

`make update_dependencies` コマンドによって、最新の `plateau` モジュールの内容に更新する。