### PR TITLE
読み込むLODを制限できるようにする

### DIFF
--- a/plateau_plugin/algorithms/load_vector.py
+++ b/plateau_plugin/algorithms/load_vector.py
@@ -34,6 +34,7 @@ from qgis.core import (
     QgsProcessingFeedback,
     QgsProcessingParameterBoolean,
     QgsProcessingParameterCrs,
+    QgsProcessingParameterEnum,
     QgsProcessingParameterFile,
     QgsProject,
 )
@@ -79,6 +80,7 @@ class PlateauVectorLoaderAlrogithm(QgsProcessingAlgorithm):
     INPUT = "INPUT"
     ONLY_HIGHEST_LOD = "ONLY_HIGHEST_LOD"
     LOAD_SEMANTIC_PARTS = "LOAD_SEMANTIC_PARTS"
+    LODS = "LODS"
     FORCE_2D = "FORCE_2D"
     APPEND_MODE = "APPEND_MODE"
     CRS = "CRS"
@@ -93,6 +95,18 @@ class PlateauVectorLoaderAlrogithm(QgsProcessingAlgorithm):
                 self.tr("PLATEAU CityGML ファイル"),
                 fileFilter=self.tr("PLATEAU CityGML ファイル (*.gml)"),
             )
+        )
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.LODS,
+                self.tr("読み込むLOD"),
+                options=["LOD0", "LOD1", "LOD2", "LOD3", "LOD4"],
+                allowMultiple=True,
+                defaultValue=1,
+            )
+        )
+        self.parameterDefinition(self.LODS).setMetadata(
+            {"widget_wrapper": {"useCheckBoxes": True, "columns": 5}}
         )
         self.addParameter(
             QgsProcessingParameterBoolean(
@@ -161,8 +175,12 @@ class PlateauVectorLoaderAlrogithm(QgsProcessingAlgorithm):
         only_highest_lod = self.parameterAsBoolean(
             parameters, self.ONLY_HIGHEST_LOD, context
         )
+        lods = self.parameterAsEnums(parameters, self.LODS, context)
+        target_lods = tuple(i in lods for i in range(5))
+
         settings = ParserSettings(
             load_semantic_parts=load_semantic_parts,
+            target_lods=target_lods,
             only_highest_lod=only_highest_lod,
         )
 

--- a/plateau_plugin/plateau/parse/parser.py
+++ b/plateau_plugin/plateau/parse/parser.py
@@ -23,6 +23,9 @@ class ParserSettings:
     load_semantic_parts: bool = False
     """部分要素 (e.g. Road の細分化の TrafficArea) に分けて読み込むかどうか"""
 
+    target_lods: tuple[bool, bool, bool, bool, bool] = (True, True, True, True, True)
+    """各LOD (0-4) を読み込みの対象にするかどうか"""
+
     only_highest_lod: bool = False
     """各Featureの最高の LoD だけ出力するかどうか"""
 
@@ -266,6 +269,9 @@ class CityObjectParser:
         lod_defs = processor.lod_list
         has_lods = processor.detect_lods(elem, nsmap)
         for lod in (4, 3, 2, 1, 0):
+            if not self._settings.target_lods[lod]:
+                continue
+
             if not has_lods[lod]:
                 continue
 


### PR DESCRIPTION
読み込むLODを制限できるようにする。デフォルトでは LOD1 のみを読み込む。

<img width="428" alt="Screenshot 2023-08-28 at 13 00 13" src="https://github.com/MIERUNE/plateau-qgis-plugin/assets/5351911/29d15fe8-6b94-4f46-b36d-2e0822065ae6">

rel: #57 