### PR TITLE
LODsの読み込み方のオプションを整理する

### DIFF
--- a/plateau_plugin/plateau/__main__.py
+++ b/plateau_plugin/plateau/__main__.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     processors.validate_processors()
 
     # settings = ParseSettings(load_semantic_parts=True)
-    settings = ParserSettings(only_highest_lod=False, load_semantic_parts=False)
+    settings = ParserSettings(only_first_found_lod=False, load_semantic_parts=False)
     parser = PlateauCityGmlParser(sys.argv[1], settings)
     parser.load_apperance()
     for count, cityobj in parser.iter_cityobjs():

--- a/plateau_plugin/plateau/parse/parser.py
+++ b/plateau_plugin/plateau/parse/parser.py
@@ -26,8 +26,11 @@ class ParserSettings:
     target_lods: tuple[bool, bool, bool, bool, bool] = (True, True, True, True, True)
     """各LOD (0-4) を読み込みの対象にするかどうか"""
 
-    only_highest_lod: bool = False
-    """各Featureの最高の LoD だけ出力するかどうか"""
+    only_first_found_lod: bool = False
+    """はじめに見つかったLODのみを出力するかどうか"""
+
+    lowest_lod_first: bool = False
+    """最小のLODから順に読むかどうか"""
 
     load_apperance: bool = False
     """Apperance (マテリアル、テクスチャ) を読み込むかどうか"""
@@ -259,10 +262,12 @@ class CityObjectParser:
         # ジオメトリを読んで出力する
         lod_defs = processor.lod_list
         has_lods = processor.detect_lods(elem, nsmap)
-        for lod in (4, 3, 2, 1, 0):
+        target_lods = (
+            (0, 1, 2, 3, 4) if self._settings.lowest_lod_first else (4, 3, 2, 1, 0)
+        )
+        for lod in target_lods:
             if not self._settings.target_lods[lod]:
                 continue
-
             if not has_lods[lod]:
                 continue
 
@@ -297,7 +302,7 @@ class CityObjectParser:
                 )
                 nogeom_emitted = True
 
-                if self._settings.only_highest_lod:
+                if self._settings.only_first_found_lod:
                     # 各Featureの最高 LoD だけ出力する設定の場合はここで離脱
                     break
 


### PR DESCRIPTION
「LOD1, LOD2, ..., LOD4」のチェックボックスと「各地物の最高 LOD のみを読み込む」を廃止・統合して、1つのセレクトボックスにまとめます。

- オプションがシンプルになる。
- "LOD3しかないデータ" などでの煩わしさや混乱が減る。
- 具体的なユースケースを考えるとこの選択肢で十分だろうと思う。

文言は後で要調整かもしれません。

![Screenshot 2023-08-28 at 21 52 49](https://github.com/MIERUNE/plateau-qgis-plugin/assets/5351911/d32cb582-1b83-4bec-b860-405d3fdfe327)

![Screenshot 2023-08-28 at 21 52 53](https://github.com/MIERUNE/plateau-qgis-plugin/assets/5351911/782503db-c51d-41a4-a560-58aa4a2e1afc)

（以前の状態は #59）

Closes: #57 
