### PR TITLE
wkbtypeの取得のエラーを修正

### DIFF
--- a/plateau_plugin/algorithms/utils/layermanger.py
+++ b/plateau_plugin/algorithms/utils/layermanger.py
@@ -27,6 +27,7 @@ from qgis.core import (
     # QgsLayerTreeGroup,
     QgsProject,
     QgsVectorLayer,
+    QgsWkbTypes,
 )
 
 from ...plateau.types import (
@@ -85,7 +86,7 @@ class LayerManager:
                 # CRSが一致する (または NoGeometry 型である)
                 geom_type_name = self._get_geometry_type_name(cityobj)
                 if isinstance(layer, QgsVectorLayer) and (
-                    layer.wkbType().name == geom_type_name
+                    QgsWkbTypes.displayString(layer.wkbType()) == geom_type_name
                     and (geom_type_name == "NoGeometry" or layer.crs() == self._crs)
                 ):
                     self._layers[layer_id] = layer


### PR DESCRIPTION
プラグインでレイヤのマージをする際に、「既存レイヤに追記できる条件」の判定で以下のエラーが出たので、該当箇所を修正してみました。なお、WindowsのQGIS3.28環境で発生しました

![image](https://github.com/MIERUNE/plateau-qgis-plugin/assets/98634289/fb127538-7aec-4ab9-b1ec-7aff3e31e7f7)
