### PR TITLE
DM (公共測量標準図式) の読み込みを一旦無効化する

### DIFF
--- a/plateau_plugin/algorithms/load_vector.py
+++ b/plateau_plugin/algorithms/load_vector.py
@@ -276,7 +276,7 @@ class PlateauVectorLoaderAlrogithm(QgsProcessingAlgorithm):
                     QgsProcessingContext.LayerDetails(
                         layer.name(),
                         context.project(),
-                        self.name(),
+                        layer.name(),
                         QgsProcessingUtils.LayerHint.Vector,  # type: ignore
                     ),
                 )

--- a/plateau_plugin/plateau/codelists/__init__.py
+++ b/plateau_plugin/plateau/codelists/__init__.py
@@ -14,7 +14,7 @@ from ..namespaces import BASE_NS as _NS
 
 
 class CodelistStore:
-    """事前定義されたコードリストまたは頒布データの ./codelists./ ディレクトリからコードを検索する"""
+    """事前定義されたコードリストまたは頒布データの ./codelists/ ディレクトリからコードを検索する"""
 
     def __init__(self, base_path: Path) -> None:
         self._base_path = base_path

--- a/plateau_plugin/plateau/parse/parser.py
+++ b/plateau_plugin/plateau/parse/parser.py
@@ -35,6 +35,9 @@ class ParserSettings:
     load_apperance: bool = False
     """Apperance (マテリアル、テクスチャ) を読み込むかどうか"""
 
+    load_dm: bool = False
+    """公共測量標準図式 (DM) を読み込むかどうか"""
+
 
 class CityObjectParser:
     def __init__(
@@ -237,7 +240,7 @@ class CityObjectParser:
                     yield child_obj
 
         # 公共測量標準図式 (DM)
-        if processor.dm_attr_container_path:
+        if self._settings.load_dm and processor.dm_attr_container_path:
             for dm in elem.iterfind(processor.dm_attr_container_path + "/*", nsmap):
                 for child_obj in self.process_cityobj_element(dm, nogeom_obj):
                     yield child_obj


### PR DESCRIPTION
(PLATEAU 3.x のデータのみに影響)

PLATEAU 3.x のデータには「DM (公共測量標準図式)」が LOD0 として収録され得ますが、その読み込みをいったん無効化します。

PLATEAU 3.x のデータを読んだ時に不思議なジオメトリデータが読み込まれる驚きを防ぐためです。今後整備が進んで、もし必要になったら、オプションで読み込めるようにすれば良いと思います。