### PR TITLE
Fix: コードリストの値 (description) が空の場合にエラーになる

### DIFF
--- a/plateau_plugin/plateau/codelists/__init__.py
+++ b/plateau_plugin/plateau/codelists/__init__.py
@@ -57,8 +57,8 @@ class CodelistStore:
             }
             for entry in doc.iterfind(".//gml:dictionaryEntry", _NS):
                 for definition in entry.iterfind(".//gml:Definition", _NS):
-                    desc = definition.find("./gml:description", _NS).text
-                    name = definition.find("./gml:name", _NS).text
+                    name = definition.find("./gml:name", _NS).text or ""
+                    desc = definition.find("./gml:description", _NS).text or ""
                     dictionary[name] = desc.replace("\u3000", " ").strip()
             self._cached[str(path)] = dictionary
             return dictionary


### PR DESCRIPTION
コード辞書のdescriptionが空文字列の場合にエラーになる問題を修正します。

<img width="500" alt="Screenshot 2023-09-08 at 15 22 20" src="https://github.com/MIERUNE/plateau-qgis-plugin/assets/5351911/6b8ef12d-320f-49af-b8aa-5d4c078ee013">