### PR TITLE
Memory provider の spatial index を有効にする

### DIFF
--- a/plateau_plugin/algorithms/utils/layermanger.py
+++ b/plateau_plugin/algorithms/utils/layermanger.py
@@ -197,7 +197,7 @@ class LayerManager:
         # make a new layer
         crs = self._crs.authid()
         geometry_type_name = self._get_geometry_type_name(cityobj)
-        layer_path = f"{geometry_type_name}?crs={crs}"
+        layer_path = f"{geometry_type_name}?crs={crs}&index=yes"
 
         layer = QgsVectorLayer(
             layer_path,


### PR DESCRIPTION
試しに、memory provider 作成時の uri をたとえば `MultiPolygonZ?crs={crs}&index=yes` のようにして、空間インデクスを有効にしてみます。（無指定時は空間インデクスは作られない）