### PR TITLE
プロセシングアルゴリズムをメインスレッドで実行させる

### DIFF
--- a/plateau_plugin/algorithms/load_vector.py
+++ b/plateau_plugin/algorithms/load_vector.py
@@ -180,6 +180,10 @@ class PlateauVectorLoaderAlrogithm(QgsProcessingAlgorithm):
             )  # pragma: no cover
         return PlateauCityGmlParser(filename, settings)
 
+    def flags(self) -> QgsProcessingAlgorithm.Flags:
+        # NOTE: Windowsなどでバッチ処理が停止する問題への暫定対応としてメインスレッドで実行する
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+
     def processAlgorithm(  # noqa: C901
         self,
         parameters: dict[str, Any],


### PR DESCRIPTION
WindowsのQGISでバッチ実行する際に途中で停止してしまう問題に対処するため、アルゴリズムをメインスレッドで実行させるように宣言する。

参考: https://docs.qgis.org/3.28/en/docs/user_manual/processing/scripts.html#flags

> By default, Processing runs algorithms in a separate thread in order to keep QGIS responsive while the processing task runs. If your algorithm is regularly crashing, you are probably using API calls which are not safe to do in a background thread. Try returning the QgsProcessingAlgorithm.FlagNoThreading flag from your algorithm’s flags() method to force Processing to run your algorithm in the main thread instead.

