### PR TITLE
gml:description を読み込むように

### DIFF
--- a/plateau_plugin/algorithms/load_vector.py
+++ b/plateau_plugin/algorithms/load_vector.py
@@ -234,6 +234,7 @@ class PlateauVectorLoaderAlrogithm(QgsProcessingAlgorithm):
             feature.setAttribute("type", cityobj.type)
             feature.setAttribute("lod", cityobj.lod)
             feature.setAttribute("name", cityobj.name)
+            feature.setAttribute("description", cityobj.description)
             feature.setAttribute(
                 "creationDate",
                 QDate(cityobj.creation_date) if cityobj.creation_date else None,  # type: ignore

--- a/plateau_plugin/algorithms/utils/layermanger.py
+++ b/plateau_plugin/algorithms/utils/layermanger.py
@@ -186,6 +186,7 @@ class LayerManager:
                 QgsField("type", QVariant.String),  # feature type
                 QgsField("lod", QVariant.Int),  # LoD
                 QgsField("name", QVariant.String),  # gml:name
+                QgsField("description", QVariant.String),  # gml:description
                 QgsField("creationDate", QVariant.Date),  # gml:creationDate
                 QgsField("terminationDate", QVariant.Date),  # gml:terminationDate
             ]

--- a/plateau_plugin/plateau/parse/parser.py
+++ b/plateau_plugin/plateau/parse/parser.py
@@ -53,8 +53,10 @@ class CityObjectParser:
         self._codelist_store = codelist_store
         self.appearance = appearance
 
-    def _get_id_and_name(self, elem: et._Element) -> tuple[str | None, str | None]:
-        """@gml:id と gml:name (あれば) を読む"""
+    def _get_id_and_name(
+        self, elem: et._Element
+    ) -> tuple[str | None, str | None, str | None]:
+        """@gml:id と gml:name (あれば) と gml:description (あれば) を読む"""
         nsmap = self._nsmap
         gml_id = elem.get("{http://www.opengis.net/gml}id", None)
         if (name_elem := elem.find("./gml:name", nsmap)) is not None:
@@ -64,7 +66,12 @@ class CityObjectParser:
         else:
             gml_name = None
 
-        return (gml_id, gml_name)
+        if (desc_elem := elem.find("./gml:description", nsmap)) is not None:
+            gml_description = desc_elem.text
+        else:
+            gml_description = None
+
+        return (gml_id, gml_name, gml_description)
 
     def _get_basic_dates(self, elem: et._Element) -> tuple[date | None, date | None]:
         """基本的な日付 core:creationDate (あれば) と core:terminationDate (あれば) を読む"""
@@ -205,7 +212,7 @@ class CityObjectParser:
         nsmap = self._nsmap
         appearance = self.appearance
 
-        (gml_id, gml_name) = self._get_id_and_name(elem)
+        (gml_id, gml_name, gml_desc) = self._get_id_and_name(elem)
         (creation_date, termination_date) = self._get_basic_dates(elem)
 
         # この要素のための Processor を得る
@@ -221,6 +228,7 @@ class CityObjectParser:
             type=ns.to_prefixed_name(elem.tag),
             id=gml_id,
             name=gml_name,
+            description=gml_desc,
             creation_date=creation_date,
             termination_date=termination_date,
             lod=None,
@@ -296,6 +304,7 @@ class CityObjectParser:
                     type=ns.to_prefixed_name(elem.tag),
                     id=gml_id,
                     name=gml_name,
+                    description=gml_desc,
                     creation_date=creation_date,
                     termination_date=termination_date,
                     attributes=props,

--- a/plateau_plugin/plateau/types.py
+++ b/plateau_plugin/plateau/types.py
@@ -51,6 +51,9 @@ class CityObject:
     name: str | None
     """gml:name"""
 
+    description: str | None
+    """gml:description"""
+
     creation_date: date | None
     """core:creationDate"""
 


### PR DESCRIPTION
いままで gml:description を地物の属性として読み込んでいなかった。（実際のところほとんど使われてこなかったとはいえ）基本の属性であり、3.xで追加される一部の都市オブジェクトではPLATEAUにおいて必須とされているので、読むことにする。