### PR TITLE
空要素を読み飛ばす

### DIFF
--- a/plateau_plugin/plateau/parse/parser.py
+++ b/plateau_plugin/plateau/parse/parser.py
@@ -142,6 +142,8 @@ class CityObjectParser:
                         value = child_elem.text
                     else:
                         continue
+                    if value is None:
+                        continue
 
                     if prop.datatype == "string":
                         v = str(value)


### PR DESCRIPTION
`<urf:validFrom></urf:validFrom>` のような空要素は、スキーマ上は不正だが、我々のライブラリでは無視して読み飛ばす。