### PR TITLE
一部の属性値の定義を見直し

### DIFF
--- a/plateau_plugin/plateau/models/building.py
+++ b/plateau_plugin/plateau/models/building.py
@@ -93,298 +93,299 @@ BUILDING = FeatureProcessingDefinition(
                 ),
             ],
         ),
-        AttributeGroup(
-            base_element="./uro:buildingDetailAttribute/uro:BuildingDetailAttribute",
-            attributes=[
-                Attribute(
-                    name="serialNumberOfBuildingCertification",
-                    path="./uro:serialNumberOfBuildingCertification",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="siteArea",
-                    path="./uro:siteArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="totalFloorArea",
-                    path="./uro:totalFloorArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buildingFootprintArea",
-                    path="./uro:buildingFootprintArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buildingRoofEdgeArea",
-                    path="./uro:buildingRoofEdgeArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="developmentArea",
-                    path="./uro:developmentArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buildingStructureType",
-                    path="./uro:buildingStructureType",
-                    datatype="string",
-                    predefined_codelist="BuildingDetailAttribute_buildingStructureType",
-                ),
-                Attribute(
-                    name="buildingStructureOrgType",
-                    path="./uro:buildingStructureOrgType",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="fireproofStructureType",
-                    path="./uro:fireproofStructureType",
-                    datatype="string",
-                    predefined_codelist="BuildingDetailAttribute_fireproofStructureType",
-                ),
-                Attribute(
-                    name="urbanPlanType",
-                    path="./uro:urbanPlanType",
-                    datatype="string",
-                    predefined_codelist=None,
-                ),
-                Attribute(
-                    name="areaClassificationType",
-                    path="./uro:areaClassificationType",
-                    datatype="string",
-                    predefined_codelist="Common_areaClassificationType",
-                ),
-                Attribute(
-                    name="districtsAndZonesType",
-                    path="./uro:districtsAndZonesType",
-                    datatype="[]string",
-                    predefined_codelist="Common_districtsAndZonesType",
-                ),
-                Attribute(
-                    name="landUseType",
-                    path="./uro:landUseType",
-                    datatype="string",
-                    predefined_codelist="Common_landUseType",
-                ),
-                Attribute(
-                    name="reference",
-                    path="./uro:reference",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="majorUsage",
-                    path="./uro:majorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="majorUsage2",
-                    path="./uro:majorUsage2",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="orgUsage",
-                    path="./uro:orgUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="orgUsage2",
-                    path="./uro:orgUsage2",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="detailedUsage",
-                    path="./uro:detailedUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="detailedUsage2",
-                    path="./uro:detailedUsage2",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="detailedUsage3",
-                    path="./uro:detailedUsage3",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="groundFloorUsage",
-                    path="./uro:groundFloorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="secondFloorUsage",
-                    path="./uro:secondFloorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="thirdFloorUsage",
-                    path="./uro:thirdFloorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="basementUsage",
-                    path="./uro:basementUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="basementFirstUsage",
-                    path="./uro:basementFirstUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="basementSecondUsage",
-                    path="./uro:basementSecondUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="vacancy",
-                    path="./uro:vacancy",
-                    datatype="string",
-                    predefined_codelist="BuildingDetailAttribute_vacancy",
-                ),
-                Attribute(
-                    name="buildingCoverageRate",
-                    path="./uro:buildingCoverageRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="floorAreaRate",
-                    path="./uro:floorAreaRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="specifiedBuildingCoverageRate",
-                    path="./uro:specifiedBuildingCoverageRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="specifiedFloorAreaRate",
-                    path="./uro:specifiedFloorAreaRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="standardFloorAreaRate",
-                    path="./uro:standardFloorAreaRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buidingHeight",
-                    path="./uro:buidingHeight",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="eaveHeight",
-                    path="./uro:eaveHeight",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="surveyYear",
-                    path="./uro:surveyYear",
-                    datatype="integer",
-                ),
-            ],
-        ),
-        AttributeGroup(
-            base_element="./uro:largeCustomerFacilityAttribute/uro:LargeCustomerFacilityAttribute",
-            attributes=[
-                Attribute(
-                    name="class",
-                    path="./uro:class",
-                    datatype="string",
-                    predefined_codelist="LargeCustomerFacilityAttribute_class",
-                ),
-                Attribute(
-                    name="name",
-                    path="./uro:name",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="capacity",
-                    path="./uro:capacity",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="owner",
-                    path="./uro:owner",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="totalFloorArea",
-                    path="./uro:totalFloorArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="totalStoreFloorArea",
-                    path="./uro:totalStoreFloorArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="inauguralDate",
-                    path="./uro:inauguralDate",
-                    datatype="date",
-                ),
-                Attribute(
-                    name="yearOpened",
-                    path="./uro:yearOpened",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="yearClosed",
-                    path="./uro:yearClosed",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="keyTenants",
-                    path="./uro:keyTenants",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="availability",
-                    path="./uro:availability",
-                    datatype="boolean",
-                ),
-                Attribute(
-                    name="urbanPlanType",
-                    path="./uro:urbanPlanType",
-                    datatype="string",
-                    predefined_codelist="Common_urbanPlanType",
-                ),
-                Attribute(
-                    name="areaClassificationType",
-                    path="./uro:areaClassificationType",
-                    datatype="string",
-                    predefined_codelist="Common_areaClassificationType",
-                ),
-                Attribute(
-                    name="districtsAndZonesType",
-                    path="./uro:districtsAndZonesType",
-                    datatype="[]string",
-                    predefined_codelist="Common_districtsAndZonesType",
-                ),
-                Attribute(
-                    name="landUseType",
-                    path="./uro:landUseType",
-                    datatype="string",
-                    predefined_codelist="Common_landUseType",
-                ),
-                Attribute(
-                    name="reference",
-                    path="./uro:reference",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="note",
-                    path="./uro:note",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="surveyYear",
-                    path="./uro:surveyYear",
-                    datatype="integer",
-                ),
-            ],
-        ),
+        # TODO: これらは入れ子的データ [0..*]
+        # AttributeGroup(
+        #     base_element="./uro:buildingDetailAttribute/uro:BuildingDetailAttribute",
+        #     attributes=[
+        #         Attribute(
+        #             name="serialNumberOfBuildingCertification",
+        #             path="./uro:serialNumberOfBuildingCertification",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="siteArea",
+        #             path="./uro:siteArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="totalFloorArea",
+        #             path="./uro:totalFloorArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buildingFootprintArea",
+        #             path="./uro:buildingFootprintArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buildingRoofEdgeArea",
+        #             path="./uro:buildingRoofEdgeArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="developmentArea",
+        #             path="./uro:developmentArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buildingStructureType",
+        #             path="./uro:buildingStructureType",
+        #             datatype="string",
+        #             predefined_codelist="BuildingDetailAttribute_buildingStructureType",
+        #         ),
+        #         Attribute(
+        #             name="buildingStructureOrgType",
+        #             path="./uro:buildingStructureOrgType",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="fireproofStructureType",
+        #             path="./uro:fireproofStructureType",
+        #             datatype="string",
+        #             predefined_codelist="BuildingDetailAttribute_fireproofStructureType",
+        #         ),
+        #         Attribute(
+        #             name="urbanPlanType",
+        #             path="./uro:urbanPlanType",
+        #             datatype="string",
+        #             predefined_codelist=None,
+        #         ),
+        #         Attribute(
+        #             name="areaClassificationType",
+        #             path="./uro:areaClassificationType",
+        #             datatype="string",
+        #             predefined_codelist="Common_areaClassificationType",
+        #         ),
+        #         Attribute(
+        #             name="districtsAndZonesType",
+        #             path="./uro:districtsAndZonesType",
+        #             datatype="[]string",
+        #             predefined_codelist="Common_districtsAndZonesType",
+        #         ),
+        #         Attribute(
+        #             name="landUseType",
+        #             path="./uro:landUseType",
+        #             datatype="string",
+        #             predefined_codelist="Common_landUseType",
+        #         ),
+        #         Attribute(
+        #             name="reference",
+        #             path="./uro:reference",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="majorUsage",
+        #             path="./uro:majorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="majorUsage2",
+        #             path="./uro:majorUsage2",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="orgUsage",
+        #             path="./uro:orgUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="orgUsage2",
+        #             path="./uro:orgUsage2",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="detailedUsage",
+        #             path="./uro:detailedUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="detailedUsage2",
+        #             path="./uro:detailedUsage2",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="detailedUsage3",
+        #             path="./uro:detailedUsage3",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="groundFloorUsage",
+        #             path="./uro:groundFloorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="secondFloorUsage",
+        #             path="./uro:secondFloorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="thirdFloorUsage",
+        #             path="./uro:thirdFloorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="basementUsage",
+        #             path="./uro:basementUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="basementFirstUsage",
+        #             path="./uro:basementFirstUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="basementSecondUsage",
+        #             path="./uro:basementSecondUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="vacancy",
+        #             path="./uro:vacancy",
+        #             datatype="string",
+        #             predefined_codelist="BuildingDetailAttribute_vacancy",
+        #         ),
+        #         Attribute(
+        #             name="buildingCoverageRate",
+        #             path="./uro:buildingCoverageRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="floorAreaRate",
+        #             path="./uro:floorAreaRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="specifiedBuildingCoverageRate",
+        #             path="./uro:specifiedBuildingCoverageRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="specifiedFloorAreaRate",
+        #             path="./uro:specifiedFloorAreaRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="standardFloorAreaRate",
+        #             path="./uro:standardFloorAreaRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buidingHeight",
+        #             path="./uro:buidingHeight",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="eaveHeight",
+        #             path="./uro:eaveHeight",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="surveyYear",
+        #             path="./uro:surveyYear",
+        #             datatype="integer",
+        #         ),
+        #     ],
+        # ),
+        # AttributeGroup(
+        #     base_element="./uro:largeCustomerFacilityAttribute/uro:LargeCustomerFacilityAttribute",
+        #     attributes=[
+        #         Attribute(
+        #             name="class",
+        #             path="./uro:class",
+        #             datatype="string",
+        #             predefined_codelist="LargeCustomerFacilityAttribute_class",
+        #         ),
+        #         Attribute(
+        #             name="name",
+        #             path="./uro:name",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="capacity",
+        #             path="./uro:capacity",
+        #             datatype="integer",
+        #         ),
+        #         Attribute(
+        #             name="owner",
+        #             path="./uro:owner",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="totalFloorArea",
+        #             path="./uro:totalFloorArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="totalStoreFloorArea",
+        #             path="./uro:totalStoreFloorArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="inauguralDate",
+        #             path="./uro:inauguralDate",
+        #             datatype="date",
+        #         ),
+        #         Attribute(
+        #             name="yearOpened",
+        #             path="./uro:yearOpened",
+        #             datatype="integer",
+        #         ),
+        #         Attribute(
+        #             name="yearClosed",
+        #             path="./uro:yearClosed",
+        #             datatype="integer",
+        #         ),
+        #         Attribute(
+        #             name="keyTenants",
+        #             path="./uro:keyTenants",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="availability",
+        #             path="./uro:availability",
+        #             datatype="boolean",
+        #         ),
+        #         Attribute(
+        #             name="urbanPlanType",
+        #             path="./uro:urbanPlanType",
+        #             datatype="string",
+        #             predefined_codelist="Common_urbanPlanType",
+        #         ),
+        #         Attribute(
+        #             name="areaClassificationType",
+        #             path="./uro:areaClassificationType",
+        #             datatype="string",
+        #             predefined_codelist="Common_areaClassificationType",
+        #         ),
+        #         Attribute(
+        #             name="districtsAndZonesType",
+        #             path="./uro:districtsAndZonesType",
+        #             datatype="[]string",
+        #             predefined_codelist="Common_districtsAndZonesType",
+        #         ),
+        #         Attribute(
+        #             name="landUseType",
+        #             path="./uro:landUseType",
+        #             datatype="string",
+        #             predefined_codelist="Common_landUseType",
+        #         ),
+        #         Attribute(
+        #             name="reference",
+        #             path="./uro:reference",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="note",
+        #             path="./uro:note",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="surveyYear",
+        #             path="./uro:surveyYear",
+        #             datatype="integer",
+        #         ),
+        #     ],
+        # ),
         AttributeGroup(
             base_element="./uro:buildingDataQualityAttribute/uro:BuildingDataQualityAttribute",
             attributes=[

--- a/plateau_plugin/plateau/models/urf_zone.py
+++ b/plateau_plugin/plateau/models/urf_zone.py
@@ -15,16 +15,6 @@ _base_attributes = [
         base_element=None,
         attributes=[
             Attribute(
-                name="function",
-                path="./urf:function",
-                datatype="[]string",
-            ),
-            Attribute(
-                name="usage",
-                path="./urf:usage",
-                datatype="[]string",
-            ),
-            Attribute(
                 name="areaClassificationType",
                 path="./urf:areaClassificationType",
                 datatype="string",
@@ -324,6 +314,18 @@ URF_DISTRICTS_AND_ZONES = FeatureProcessingDefinition(
                     path="./urf:function",
                     datatype="[]string",
                     predefined_codelist="Common_districtsAndZonesType",
+                ),
+                Attribute(
+                    name="usage",
+                    path="./urf:usage",
+                    datatype="[]string",
+                    predefined_codelist={
+                        "urf:SpecialUseDistrict": "SpecialUseDistrict_usage",
+                        "urf:HeightControlDistrict": "HeightControlDistrict_usage",
+                        "urf:FirePreventionDistrict": "FirePreventionDistrict_usage",
+                        "urf:ScenicDistrict": "ScenicDistrict_usage",
+                        "urf:PortZone": "PortZone_usage",
+                    },
                 ),
                 Attribute(
                     name="areaInTotal",
@@ -1006,6 +1008,9 @@ URF_URBAN_DEVELOPMENT_PROJECT = FeatureProcessingDefinition(
                     name="usage",
                     path="./urf:usage",
                     datatype="[]string",
+                    predefined_codelist={
+                        "urf:UrbanRedevelopmentProject": "UrbanRedevelopmentProject_usage",
+                    },
                 ),
                 Attribute(
                     name="buildingLotDevelopment",

--- a/plateau_plugin/plateau/models/uro_underground_building.py
+++ b/plateau_plugin/plateau/models/uro_underground_building.py
@@ -85,298 +85,299 @@ UNDERGROUND_BUILDING = FeatureProcessingDefinition(
                 ),
             ],
         ),
-        AttributeGroup(
-            base_element="./uro:buildingDetailAttribute/uro:BuildingDetailAttribute",
-            attributes=[
-                Attribute(
-                    name="serialNumberOfBuildingCertification",
-                    path="./uro:serialNumberOfBuildingCertification",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="siteArea",
-                    path="./uro:siteArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="totalFloorArea",
-                    path="./uro:totalFloorArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buildingFootprintArea",
-                    path="./uro:buildingFootprintArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buildingRoofEdgeArea",
-                    path="./uro:buildingRoofEdgeArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="developmentArea",
-                    path="./uro:developmentArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buildingStructureType",
-                    path="./uro:buildingStructureType",
-                    datatype="string",
-                    predefined_codelist="BuildingDetailAttribute_buildingStructureType",
-                ),
-                Attribute(
-                    name="buildingStructureOrgType",
-                    path="./uro:buildingStructureOrgType",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="fireproofStructureType",
-                    path="./uro:fireproofStructureType",
-                    datatype="string",
-                    predefined_codelist="BuildingDetailAttribute_fireproofStructureType",
-                ),
-                Attribute(
-                    name="urbanPlanType",
-                    path="./uro:urbanPlanType",
-                    datatype="string",
-                    predefined_codelist=None,
-                ),
-                Attribute(
-                    name="areaClassificationType",
-                    path="./uro:areaClassificationType",
-                    datatype="string",
-                    predefined_codelist="Common_areaClassificationType",
-                ),
-                Attribute(
-                    name="districtsAndZonesType",
-                    path="./uro:districtsAndZonesType",
-                    datatype="[]string",
-                    predefined_codelist="Common_districtsAndZonesType",
-                ),
-                Attribute(
-                    name="landUseType",
-                    path="./uro:landUseType",
-                    datatype="string",
-                    predefined_codelist="Common_landUseType",
-                ),
-                Attribute(
-                    name="reference",
-                    path="./uro:reference",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="majorUsage",
-                    path="./uro:majorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="majorUsage2",
-                    path="./uro:majorUsage2",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="orgUsage",
-                    path="./uro:orgUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="orgUsage2",
-                    path="./uro:orgUsage2",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="detailedUsage",
-                    path="./uro:detailedUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="detailedUsage2",
-                    path="./uro:detailedUsage2",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="detailedUsage3",
-                    path="./uro:detailedUsage3",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="groundFloorUsage",
-                    path="./uro:groundFloorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="secondFloorUsage",
-                    path="./uro:secondFloorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="thirdFloorUsage",
-                    path="./uro:thirdFloorUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="basementUsage",
-                    path="./uro:basementUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="basementFirstUsage",
-                    path="./uro:basementFirstUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="basementSecondUsage",
-                    path="./uro:basementSecondUsage",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="vacancy",
-                    path="./uro:vacancy",
-                    datatype="string",
-                    predefined_codelist="BuildingDetailAttribute_vacancy",
-                ),
-                Attribute(
-                    name="buildingCoverageRate",
-                    path="./uro:buildingCoverageRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="floorAreaRate",
-                    path="./uro:floorAreaRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="specifiedBuildingCoverageRate",
-                    path="./uro:specifiedBuildingCoverageRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="specifiedFloorAreaRate",
-                    path="./uro:specifiedFloorAreaRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="standardFloorAreaRate",
-                    path="./uro:standardFloorAreaRate",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="buidingHeight",
-                    path="./uro:buidingHeight",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="eaveHeight",
-                    path="./uro:eaveHeight",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="surveyYear",
-                    path="./uro:surveyYear",
-                    datatype="integer",
-                ),
-            ],
-        ),
-        AttributeGroup(
-            base_element="./uro:largeCustomerFacilityAttribute/uro:LargeCustomerFacilityAttribute",
-            attributes=[
-                Attribute(
-                    name="class",
-                    path="./uro:class",
-                    datatype="string",
-                    predefined_codelist="LargeCustomerFacilityAttribute_class",
-                ),
-                Attribute(
-                    name="name",
-                    path="./uro:name",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="capacity",
-                    path="./uro:capacity",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="owner",
-                    path="./uro:owner",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="totalFloorArea",
-                    path="./uro:totalFloorArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="totalStoreFloorArea",
-                    path="./uro:totalStoreFloorArea",
-                    datatype="double",
-                ),
-                Attribute(
-                    name="inauguralDate",
-                    path="./uro:inauguralDate",
-                    datatype="date",
-                ),
-                Attribute(
-                    name="yearOpened",
-                    path="./uro:yearOpened",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="yearClosed",
-                    path="./uro:yearClosed",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="keyTenants",
-                    path="./uro:keyTenants",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="availability",
-                    path="./uro:availability",
-                    datatype="boolean",
-                ),
-                Attribute(
-                    name="urbanPlanType",
-                    path="./uro:urbanPlanType",
-                    datatype="string",
-                    predefined_codelist="Common_urbanPlanType",
-                ),
-                Attribute(
-                    name="areaClassificationType",
-                    path="./uro:areaClassificationType",
-                    datatype="string",
-                    predefined_codelist="Common_areaClassificationType",
-                ),
-                Attribute(
-                    name="districtsAndZonesType",
-                    path="./uro:districtsAndZonesType",
-                    datatype="[]string",
-                    predefined_codelist="Common_districtsAndZonesType",
-                ),
-                Attribute(
-                    name="landUseType",
-                    path="./uro:landUseType",
-                    datatype="string",
-                    predefined_codelist="Common_landUseType",
-                ),
-                Attribute(
-                    name="reference",
-                    path="./uro:reference",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="note",
-                    path="./uro:note",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="surveyYear",
-                    path="./uro:surveyYear",
-                    datatype="integer",
-                ),
-            ],
-        ),
+        # TODO: 入れ子的属性
+        # AttributeGroup(
+        #     base_element="./uro:buildingDetailAttribute/uro:BuildingDetailAttribute",
+        #     attributes=[
+        #         Attribute(
+        #             name="serialNumberOfBuildingCertification",
+        #             path="./uro:serialNumberOfBuildingCertification",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="siteArea",
+        #             path="./uro:siteArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="totalFloorArea",
+        #             path="./uro:totalFloorArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buildingFootprintArea",
+        #             path="./uro:buildingFootprintArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buildingRoofEdgeArea",
+        #             path="./uro:buildingRoofEdgeArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="developmentArea",
+        #             path="./uro:developmentArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buildingStructureType",
+        #             path="./uro:buildingStructureType",
+        #             datatype="string",
+        #             predefined_codelist="BuildingDetailAttribute_buildingStructureType",
+        #         ),
+        #         Attribute(
+        #             name="buildingStructureOrgType",
+        #             path="./uro:buildingStructureOrgType",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="fireproofStructureType",
+        #             path="./uro:fireproofStructureType",
+        #             datatype="string",
+        #             predefined_codelist="BuildingDetailAttribute_fireproofStructureType",
+        #         ),
+        #         Attribute(
+        #             name="urbanPlanType",
+        #             path="./uro:urbanPlanType",
+        #             datatype="string",
+        #             predefined_codelist=None,
+        #         ),
+        #         Attribute(
+        #             name="areaClassificationType",
+        #             path="./uro:areaClassificationType",
+        #             datatype="string",
+        #             predefined_codelist="Common_areaClassificationType",
+        #         ),
+        #         Attribute(
+        #             name="districtsAndZonesType",
+        #             path="./uro:districtsAndZonesType",
+        #             datatype="[]string",
+        #             predefined_codelist="Common_districtsAndZonesType",
+        #         ),
+        #         Attribute(
+        #             name="landUseType",
+        #             path="./uro:landUseType",
+        #             datatype="string",
+        #             predefined_codelist="Common_landUseType",
+        #         ),
+        #         Attribute(
+        #             name="reference",
+        #             path="./uro:reference",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="majorUsage",
+        #             path="./uro:majorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="majorUsage2",
+        #             path="./uro:majorUsage2",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="orgUsage",
+        #             path="./uro:orgUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="orgUsage2",
+        #             path="./uro:orgUsage2",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="detailedUsage",
+        #             path="./uro:detailedUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="detailedUsage2",
+        #             path="./uro:detailedUsage2",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="detailedUsage3",
+        #             path="./uro:detailedUsage3",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="groundFloorUsage",
+        #             path="./uro:groundFloorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="secondFloorUsage",
+        #             path="./uro:secondFloorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="thirdFloorUsage",
+        #             path="./uro:thirdFloorUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="basementUsage",
+        #             path="./uro:basementUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="basementFirstUsage",
+        #             path="./uro:basementFirstUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="basementSecondUsage",
+        #             path="./uro:basementSecondUsage",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="vacancy",
+        #             path="./uro:vacancy",
+        #             datatype="string",
+        #             predefined_codelist="BuildingDetailAttribute_vacancy",
+        #         ),
+        #         Attribute(
+        #             name="buildingCoverageRate",
+        #             path="./uro:buildingCoverageRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="floorAreaRate",
+        #             path="./uro:floorAreaRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="specifiedBuildingCoverageRate",
+        #             path="./uro:specifiedBuildingCoverageRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="specifiedFloorAreaRate",
+        #             path="./uro:specifiedFloorAreaRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="standardFloorAreaRate",
+        #             path="./uro:standardFloorAreaRate",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="buidingHeight",
+        #             path="./uro:buidingHeight",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="eaveHeight",
+        #             path="./uro:eaveHeight",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="surveyYear",
+        #             path="./uro:surveyYear",
+        #             datatype="integer",
+        #         ),
+        #     ],
+        # ),
+        # AttributeGroup(
+        #     base_element="./uro:largeCustomerFacilityAttribute/uro:LargeCustomerFacilityAttribute",
+        #     attributes=[
+        #         Attribute(
+        #             name="class",
+        #             path="./uro:class",
+        #             datatype="string",
+        #             predefined_codelist="LargeCustomerFacilityAttribute_class",
+        #         ),
+        #         Attribute(
+        #             name="name",
+        #             path="./uro:name",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="capacity",
+        #             path="./uro:capacity",
+        #             datatype="integer",
+        #         ),
+        #         Attribute(
+        #             name="owner",
+        #             path="./uro:owner",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="totalFloorArea",
+        #             path="./uro:totalFloorArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="totalStoreFloorArea",
+        #             path="./uro:totalStoreFloorArea",
+        #             datatype="double",
+        #         ),
+        #         Attribute(
+        #             name="inauguralDate",
+        #             path="./uro:inauguralDate",
+        #             datatype="date",
+        #         ),
+        #         Attribute(
+        #             name="yearOpened",
+        #             path="./uro:yearOpened",
+        #             datatype="integer",
+        #         ),
+        #         Attribute(
+        #             name="yearClosed",
+        #             path="./uro:yearClosed",
+        #             datatype="integer",
+        #         ),
+        #         Attribute(
+        #             name="keyTenants",
+        #             path="./uro:keyTenants",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="availability",
+        #             path="./uro:availability",
+        #             datatype="boolean",
+        #         ),
+        #         Attribute(
+        #             name="urbanPlanType",
+        #             path="./uro:urbanPlanType",
+        #             datatype="string",
+        #             predefined_codelist="Common_urbanPlanType",
+        #         ),
+        #         Attribute(
+        #             name="areaClassificationType",
+        #             path="./uro:areaClassificationType",
+        #             datatype="string",
+        #             predefined_codelist="Common_areaClassificationType",
+        #         ),
+        #         Attribute(
+        #             name="districtsAndZonesType",
+        #             path="./uro:districtsAndZonesType",
+        #             datatype="[]string",
+        #             predefined_codelist="Common_districtsAndZonesType",
+        #         ),
+        #         Attribute(
+        #             name="landUseType",
+        #             path="./uro:landUseType",
+        #             datatype="string",
+        #             predefined_codelist="Common_landUseType",
+        #         ),
+        #         Attribute(
+        #             name="reference",
+        #             path="./uro:reference",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="note",
+        #             path="./uro:note",
+        #             datatype="string",
+        #         ),
+        #         Attribute(
+        #             name="surveyYear",
+        #             path="./uro:surveyYear",
+        #             datatype="integer",
+        #         ),
+        #     ],
+        # ),
         AttributeGroup(
             base_element="./uro:buildingDataQualityAttribute/uro:BuildingDataQualityAttribute",
             attributes=[


### PR DESCRIPTION
- Building, UndergroundBuliding の `uro:BuildingDetailAttribute` と `uro:LargeCustomerFacilityAttribute` は入れ子的な属性として扱うべきなので、いったんコメントアウト。
- 都市計画決定情報において urf:function と urf:usage の定義が重複していたのを解消。