### PR TITLE
PLATEAU 1.x の都市計画決定情報もLOD1として扱う

### DIFF
--- a/plateau_plugin/plateau/models/urf_zone/district_dev_plans.py
+++ b/plateau_plugin/plateau/models/urf_zone/district_dev_plans.py
@@ -53,15 +53,13 @@ _COMMON_ATTRS = [
 ]
 
 _COMMON_GEOMETRIES = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
     semantic_parts=[
         "./urf:districtFacility/*",

--- a/plateau_plugin/plateau/models/urf_zone/district_facilities.py
+++ b/plateau_plugin/plateau/models/urf_zone/district_facilities.py
@@ -29,15 +29,13 @@ _COMMON_ATTRS = [
 ]
 
 _COMMON_GEOMETRIES = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
 )
 

--- a/plateau_plugin/plateau/models/urf_zone/district_plans.py
+++ b/plateau_plugin/plateau/models/urf_zone/district_plans.py
@@ -38,15 +38,13 @@ _ABSTRACT_ATTRS = [
 ]
 
 _ABSTRACT_GEOMETRIES = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
     semantic_parts=[
         "./urf:districtDevelopmentPlan/*",

--- a/plateau_plugin/plateau/models/urf_zone/districts_and_zones.py
+++ b/plateau_plugin/plateau/models/urf_zone/districts_and_zones.py
@@ -33,15 +33,13 @@ _COMMON_ATTRS = [
 ]
 
 _COMMON_GEOMETRIC = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
 )
 

--- a/plateau_plugin/plateau/models/urf_zone/promotion_areas.py
+++ b/plateau_plugin/plateau/models/urf_zone/promotion_areas.py
@@ -38,15 +38,13 @@ _COMMON_ATTRS = [
 ]
 
 _COMMON_GEOMETRIES = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
 )
 

--- a/plateau_plugin/plateau/models/urf_zone/scheduled_areas.py
+++ b/plateau_plugin/plateau/models/urf_zone/scheduled_areas.py
@@ -33,15 +33,13 @@ _COMMON_ATTRS = [
 ]
 
 _COMMON_GEOMETRIES = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
 )
 

--- a/plateau_plugin/plateau/models/urf_zone/urban_dev_projects.py
+++ b/plateau_plugin/plateau/models/urf_zone/urban_dev_projects.py
@@ -33,15 +33,13 @@ _COMMON_ATTRS = [
 ]
 
 _COMMON_GEOMETRIES = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
 )
 

--- a/plateau_plugin/plateau/models/urf_zone/urban_facilities.py
+++ b/plateau_plugin/plateau/models/urf_zone/urban_facilities.py
@@ -48,15 +48,13 @@ _STIPULATED_ATTRS = [
 ]
 
 _COMMON_GEOMETRIES = GeometricAttributes(
-    lod0=GeometricAttribute(
-        is2d=True,
-        lod_detection=["./urf:lod0MultiSurface"],
-        collect_all=["./urf:lod0MultiSurface//gml:Polygon"],
-    ),
     lod1=GeometricAttribute(
         is2d=True,
-        lod_detection=["./urf:lod1MultiSurface"],
-        collect_all=["./urf:lod1MultiSurface//gml:Polygon"],
+        lod_detection=["./urf:lod1MultiSurface", "./urf:lod0MultiSurface"],
+        collect_all=[
+            "./urf:lod1MultiSurface//gml:Polygon",
+            "./urf:lod0MultiSurface//gml:Polygon",
+        ],
     ),
 )
 


### PR DESCRIPTION
PLATEAU 1.x のデータでは都市計画決定情報が「LOD0」として表現されているが、現在の版との統一性を考えてLOD1相当として読み込むことにする。