### PR TITLE
プラグインの名称を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PLATEAU QGIS プラグイン
+# PLATEAU QGIS Plugin
 
 オープンソースの GIS アプリケーション [QGIS](https://www.qgis.org/) で「PLATEAU 3D 都市モデル」を読み込むためのプラグイン（ベータ版）です。PLATEAU の「3D 都市モデル標準製品仕様書 第 3.0 版」に対応した CityGML ファイルを読み込むことができます。
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,4 +1,4 @@
-# PLATEAU QGISプラグイン(plateau-qgis-plugin)
+# PLATEAU QGIS Plugin(plateau-qgis-plugin)
 
 #### PLATEAU 3D都市モデルを読み込む
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,4 +1,4 @@
-# PLATEAU QGIS Plugin(plateau-qgis-plugin)
+# PLATEAU QGIS Plugin (plateau-qgis-plugin)
 
 #### PLATEAU 3D都市モデルを読み込む
 

--- a/plateau_plugin/metadata.txt
+++ b/plateau_plugin/metadata.txt
@@ -1,5 +1,5 @@
 [general]
-name=PLATEAU 3D City Models
+name=PLATEAU QGIS Plugin
 version=0.0.2
 qgisMinimumVersion=3.6
 description=Import the PLATEAU 3D City Models (CityGML) used in Japan — PLATEAU 3D都市モデルのCityGMLファイルをQGISに読み込みます


### PR DESCRIPTION
プラグインの名称を「PLATEAU QGIS Plugin」に統一する。