### PR TITLE
Fix: bldg:class の扱いが抜けている

### DIFF
--- a/plateau_plugin/metadata.txt
+++ b/plateau_plugin/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=PLATEAU QGIS Plugin
-version=0.0.4
+version=0.0.5
 qgisMinimumVersion=3.6
 description=Import the PLATEAU 3D city model data (CityGML) used in Japan — PLATEAU 3D都市モデルのCityGMLファイルをQGISに読み込みます
 author=MLIT Japan

--- a/plateau_plugin/plateau/models/building.py
+++ b/plateau_plugin/plateau/models/building.py
@@ -24,6 +24,12 @@ BUILDING = FeatureProcessingDefinition(
             base_element=None,
             attributes=[
                 Attribute(
+                    name="class",
+                    path="./bldg:class",
+                    datatype="[]string",
+                    predefined_codelist="Building_class",
+                ),
+                Attribute(
                     name="usage",
                     path="./bldg:usage",
                     datatype="[]string",

--- a/plateau_plugin/plateau/models/landuse.py
+++ b/plateau_plugin/plateau/models/landuse.py
@@ -158,7 +158,7 @@ LAND_USE = FeatureProcessingDefinition(
             ],
             collect_all=[
                 "./luse:lod0MultiSurface//gml:Polygon",  # NOTE: PLATEAU 2.0 compatibility
-                "./luse:lod1MultiSurface//gml:Polygon"
+                "./luse:lod1MultiSurface//gml:Polygon",
             ],
         ),
     ),


### PR DESCRIPTION
Closes: #118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - 建物の属性グループに`class`属性を追加しました。これは`[]string`データ型で、`Building_class`のコードリストが事前に定義されています。
- **ドキュメント**
    - PLATEAU QGISプラグインのバージョン番号を0.0.4から0.0.5に更新しました。この変更により、QGISバージョン3.6との互換性が維持されます。また、説明文には、CityGMLフォーマットの3D都市モデルデータをQGISにインポートするための日本語テキストが含まれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->