### PR TITLE
bldgRealEstateIDAttribute を Building に直接含める

### DIFF
--- a/plateau_plugin/plateau/models/__init__.py
+++ b/plateau_plugin/plateau/models/__init__.py
@@ -24,7 +24,6 @@ from .building import (
     BUILDING_INT_INSTALLATION,
     BUILDING_OPENING,
     LARGE_CUSTOMER_FACILITY_ATTRIBUTE,
-    REAL_ESTATE_ID_ATTRIBUTE,
 )
 from .cityfurniture import CITY_FURNITURE, CITY_FURNITURE_DETAIL_ATTRIBUTE
 from .generics import GENERIC_CITY_OBJECT
@@ -82,7 +81,6 @@ processors = ProcessorRegistory(
         BUILDING_FURNITURE,
         BUILDING_DETAIL,
         LARGE_CUSTOMER_FACILITY_ATTRIBUTE,
-        REAL_ESTATE_ID_ATTRIBUTE,
         # bridge
         BRIDGE,
         BRIDGE_BOUNDARY_SURFACE,

--- a/plateau_plugin/plateau/models/building.py
+++ b/plateau_plugin/plateau/models/building.py
@@ -18,7 +18,6 @@ BUILDING = FeatureProcessingDefinition(
         "./uro:buildingDetails/uro:BuildingDetails",  # PLATEAU v1.x
         "./uro:largeCustomerFacilityAttribute/uro:LargeCustomerFacilityAttribute",
         "./uro:largeCustomerFacilities/uro:LargeCustomerFacilities",  # PLATEAU v1.x
-        "./uro:bldgRealEstateIDAttribute/uro:RealEstateIDAttribute",
     ],
     attribute_groups=[
         AttributeGroup(
@@ -143,6 +142,41 @@ BUILDING = FeatureProcessingDefinition(
                     name="lodType",
                     path="./uro:lodType",
                     datatype="[]string",
+                ),
+            ],
+        ),
+        AttributeGroup(
+            base_element="./uro:bldgRealEstateIDAttribute/uro:RealEstateIDAttribute",
+            attributes=[
+                Attribute(
+                    name="realEstateIDOfBuilding",
+                    path="./uro:realEstateIDOfBuilding",
+                    datatype="string",
+                ),
+                Attribute(
+                    name="numberOfBuildingUnitOwnership",
+                    path="./uro:numberOfBuildingUnitOwnership",
+                    datatype="integer",
+                ),
+                Attribute(
+                    name="realEstateIDOfBuildingUnitOwnership",
+                    path="./uro:realEstateIDOfBuildingUnitOwnership",
+                    datatype="[]string",
+                ),
+                Attribute(
+                    name="numberOfRealEstateIDOfLand",
+                    path="./uro:numberOfRealEstateIDOfLand",
+                    datatype="integer",
+                ),
+                Attribute(
+                    name="realEstateIDOfLand",
+                    path="./uro:realEstateIDOfLand",
+                    datatype="[]string",
+                ),
+                Attribute(
+                    name="matchingScore",
+                    path="./uro:matchingScore",
+                    datatype="integer",
                 ),
             ],
         ),
@@ -703,52 +737,6 @@ LARGE_CUSTOMER_FACILITY_ATTRIBUTE = FeatureProcessingDefinition(
                 Attribute(
                     name="surveyYear",
                     path="./uro:surveyYear",
-                    datatype="integer",
-                ),
-            ],
-        ),
-    ],
-    geometries=GeometricAttributes(),
-)
-
-
-REAL_ESTATE_ID_ATTRIBUTE = FeatureProcessingDefinition(
-    id="uro:RealEstateIDAttribute",
-    name="RealEstateIDAttribute",
-    target_elements=["uro:RealEstateIDAttribute"],
-    non_geometric=True,
-    attribute_groups=[
-        AttributeGroup(
-            base_element=None,
-            attributes=[
-                Attribute(
-                    name="realEstateIDOfBuilding",
-                    path="./uro:realEstateIDOfBuilding",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="numberOfBuildingUnitOwnership",
-                    path="./uro:numberOfBuildingUnitOwnership",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="realEstateIDOfBuildingUnitOwnership",
-                    path="./uro:realEstateIDOfBuildingUnitOwnership",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="numberOfRealEstateIDOfLand",
-                    path="./uro:numberOfRealEstateIDOfLand",
-                    datatype="integer",
-                ),
-                Attribute(
-                    name="realEstateIDOfLand",
-                    path="./uro:realEstateIDOfLand",
-                    datatype="string",
-                ),
-                Attribute(
-                    name="matchingScore",
-                    path="./uro:matchingScore",
                     datatype="integer",
                 ),
             ],


### PR DESCRIPTION
#120 による不動産IDの対応では、不動産IDまわりの属性をBuildingとは別のテーブルに収める形で対応した。

しかし bldg:Building/uro:bldgRealEstateIDAttribute は、多重度が [0..1] であるため、Building のカラムとして直接持たせることもできる。このPRはそのような読み込み方法に変更する。

また、以下2つのプロパティ値の型を `[]string` に変更する：

- `uro:realEstateIDOfBuilding`
- `uro:realEstateIDOfBuildingUnitOwnership`

![Untitled](https://github.com/MIERUNE/plateau-qgis-plugin/assets/5351911/7db5d90e-2ebe-409e-b821-8dca0799813b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- 建物および大規模顧客施設の属性に関連するセマンティック構造から`REAL_ESTATE_ID_ATTRIBUTE`宣言を削除しました。
	- 建物の詳細に関連する属性グループに大きな変更を加え、`uro:bldgRealEstateIDAttribute`を削除し、`realEstateIDOfBuilding`、`numberOfBuildingUnitOwnership`などのさまざまな属性を含む新しい属性グループ`AttributeGroup`に置き換えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->